### PR TITLE
[File-Handle]Make File Handle More Flexible with Read/Write File

### DIFF
--- a/file_module/enc/file_module.h
+++ b/file_module/enc/file_module.h
@@ -6,6 +6,21 @@
 #include "file_module_base.h"
 
 typedef enum {
+    FILE_OP_MODE_TXT_READ = 0,
+    FILE_OP_MODE_TXT_WRITE,
+    FILE_OP_MODE_TXT_APPEND,
+    FILE_OP_MODE_TXT_READ_PLUS,
+    FILE_OP_MODE_TXT_WRITE_PLUS,
+    FILE_OP_MODE_TXT_APPEND_PLUS,
+    FILE_OP_MODE_BIN_READ,
+    FILE_OP_MODE_BIN_WRITE,
+    FILE_OP_MODE_BIN_APPEND,
+    FILE_OP_MODE_BIN_READ_PLUS,
+    FILE_OP_MODE_BIN_WRITE_PLUS,
+    FILE_OP_MODE_BIN_APPEND_PLUS,
+} file_operation_mode_t;
+
+typedef enum {
     FILE_MODULE_SUCCESS = 0,
     FILE_MODULE_IFACE_INVALID,
     FILE_MODULE_CONTEXT_INVALID,
@@ -35,7 +50,7 @@ typedef struct file_handle {
     IFILE_HANDLE_BASE(file_handle);
 } ifile_handle_t;
 
-ifile_handle_t* create_file_handle(void);
+ifile_handle_t* create_file_handle(char* file_path, file_operation_mode_t mode);
 int32_t destroy_file_handle(ifile_handle_t* p_ifile_handle);
 
 #endif  // _FILE_MODULE_H

--- a/file_module/enc/file_module.h
+++ b/file_module/enc/file_module.h
@@ -35,7 +35,7 @@ typedef struct file_handle {
     IFILE_HANDLE_BASE(file_handle);
 } ifile_handle_t;
 
-ifile_handle_t* New_FILE_HANDLE(void);
-int32_t Delete_FILE_HANDLE(ifile_handle_t* p_ifile_handle);
+ifile_handle_t* create_file_handle(void);
+int32_t destroy_file_handle(ifile_handle_t* p_ifile_handle);
 
 #endif  // _FILE_MODULE_H

--- a/file_module/enc/file_module.h
+++ b/file_module/enc/file_module.h
@@ -28,6 +28,7 @@ typedef enum {
     FILE_MODULE_INSTANCE_INVALID,
     FILE_MODULE_INCORRECT_PARAM,
     FILE_MODULE_OUT_OF_MEMORY,
+    FILE_MODULE_FP_INVALID,
 } file_module_return_t;
 
 typedef enum { GET_STR_RESERVED = 0, GET_STR_BASE_NAME = 1, GET_STR_EXTENSION = 2 } ifile_get_str_t;

--- a/file_module/enc/file_module_base.h
+++ b/file_module/enc/file_module_base.h
@@ -6,7 +6,8 @@
 #define IFILE_HANDLE_BASE(iface)                                                             \
     int32_t (*init)(struct iface * p_iface);                                                 \
     int32_t (*uninit)(struct iface * p_iface);                                               \
-    int32_t (*make_instance)(struct iface * p_iface, char* file_path);                       \
+    int32_t (*make_instance)(struct iface * p_iface, const char* file_path,                  \
+                             const int32_t operation_mode);                                  \
     int32_t (*get_base_version)(struct iface * p_iface, char* base_version);                 \
     int32_t (*get_string)(struct iface * p_iface, int32_t str_type, char* get_string);       \
     int32_t (*get_integer)(struct iface * p_iface, int32_t int_type, int32_t * get_integer); \

--- a/file_module/enc/file_module_base.h
+++ b/file_module/enc/file_module_base.h
@@ -1,6 +1,8 @@
 #ifndef _FILE_MODULE_BASE_H
 #define _FILE_MODULE_BASE_H
 
+#include <stdio.h>
+
 #define FILE_HANDLE_BASE_VER "0.1.0"
 
 #define IFILE_HANDLE_BASE(iface)                                                             \
@@ -9,6 +11,7 @@
     int32_t (*make_instance)(struct iface * p_iface, const char* file_path,                  \
                              const int32_t operation_mode);                                  \
     int32_t (*get_base_version)(struct iface * p_iface, char* base_version);                 \
+    int32_t (*get_file_stream)(struct iface * p_iface, FILE * get_fp);                       \
     int32_t (*get_string)(struct iface * p_iface, int32_t str_type, char* get_string);       \
     int32_t (*get_integer)(struct iface * p_iface, int32_t int_type, int32_t * get_integer); \
     int32_t (*get_buffer)(struct iface * p_iface, int32_t buff_type, uint8_t * buffer,       \

--- a/file_module/inc/file_utils.h
+++ b/file_module/inc/file_utils.h
@@ -19,8 +19,8 @@ typedef enum {
 #endif
 
 size_t get_file_size(FILE* fp);
-char* get_file_base_name(char* file_path);
-char* get_file_extension_name(char* file_path);
+char* get_file_base_name(const char* file_path);
+char* get_file_extension_name(const char* file_path);
 int read_file_to_buffer(FILE* fp, unsigned char* file_buffer, size_t* file_data_length);
 int read_file_to_string(FILE* fp, unsigned char* file_in_string, size_t* file_in_string_length);
 

--- a/file_module/src/file_module.c
+++ b/file_module/src/file_module.c
@@ -346,7 +346,7 @@ EXIT:
     return retval;
 }
 
-ifile_handle_t* New_FILE_HANDLE(void) {
+ifile_handle_t* create_file_handle(void) {
     // TODO: Reference counting in file module.
     ifile_handle_t* p_file_handle = (ifile_handle_t*)calloc(1, sizeof(ifile_handle_t));
     file_handle_set_impl(p_file_handle);
@@ -355,7 +355,7 @@ ifile_handle_t* New_FILE_HANDLE(void) {
     return p_file_handle;
 }
 
-int32_t Delete_FILE_HANDLE(ifile_handle_t* p_ifile_handle) {
+int32_t destroy_file_handle(ifile_handle_t* p_ifile_handle) {
     // TODO: Reference counting in file module.
     int32_t retval = FILE_MODULE_SUCCESS;
 

--- a/file_module/src/file_module.c
+++ b/file_module/src/file_module.c
@@ -38,6 +38,7 @@ typedef struct file_contents {
 typedef struct file_data {
     FILE* fp;
     size_t size;
+    char* operation_mode;
     char* base_name;
     char* ext_name;
     file_contents_t contents_buffer;
@@ -46,12 +47,17 @@ typedef struct file_data {
 
 static int32_t check_file_handle(ifile_handle_t* p_ifile_handle);
 
-static int file_handle_set_impl(ifile_handle_t* p_ifile_handle);
+static int file_handle_set_impl(ifile_handle_t* p_ifile_handle, const int32_t op_mode);
+static FILE* get_file_pointer(ifile_handle_t* p_ifile_handle);
 
 static int32_t file_handle_init_impl(ifile_handle_t* p_ifile_handle);
 static int32_t file_handle_uninit_impl(ifile_handle_t* p_ifile_handle);
-static int32_t file_handle_make_instance_impl(ifile_handle_t* p_ifile_handle, const char* file_path,
-                                              const int32_t op_mode);
+
+static int32_t file_handle_read_make_instance_impl(ifile_handle_t* p_ifile_handle,
+                                                   const char* file_path, const int32_t op_mode);
+static int32_t file_handle_write_make_instance_impl(ifile_handle_t* p_ifile_handle,
+                                                    const char* file_path, const int32_t op_mode);
+
 static int32_t file_handle_get_base_version_impl(ifile_handle_t* p_ifile_handle,
                                                  char* base_version);
 static int32_t file_handle_get_string_impl(ifile_handle_t* p_ifile_handle, int32_t str_type,
@@ -60,6 +66,9 @@ static int32_t file_handle_get_integer_impl(ifile_handle_t* p_ifile_handle, int3
                                             int32_t* get_int);
 static int32_t file_handle_get_buffer_impl(ifile_handle_t* p_ifile_handle, int32_t buff_type,
                                            uint8_t* get_buff, uint32_t* buff_size);
+
+static int32_t file_handle_get_read_file_stream_impl(ifile_handle_t* p_ifile_handle, FILE* get_fp);
+static int32_t file_handle_get_write_file_stream_impl(ifile_handle_t* p_ifile_handle, FILE* get_fp);
 
 static int32_t check_file_handle(ifile_handle_t* p_ifile_handle) {
     file_module_return_t retval = FILE_MODULE_SUCCESS;
@@ -85,16 +94,35 @@ EXIT:
     return retval;
 }
 
-static int file_handle_set_impl(ifile_handle_t* p_ifile_handle) {
+static FILE* get_file_pointer(ifile_handle_t* p_ifile_handle) {
+    file_module_return_t check_status = check_file_handle(p_ifile_handle);
+    if (FILE_MODULE_SUCCESS != check_status) {
+        log_error("%s, status = %d", __func__, check_status);
+        return NULL;
+    }
+
+    file_data_t* file_data = (file_data_t*)p_ifile_handle->context;
+    return (file_data->fp);
+}
+
+static int file_handle_set_impl(ifile_handle_t* p_ifile_handle, const int32_t op_mode) {
     file_module_return_t retval = FILE_MODULE_SUCCESS;
 
     p_ifile_handle->init = file_handle_init_impl;
     p_ifile_handle->uninit = file_handle_uninit_impl;
-    p_ifile_handle->make_instance = file_handle_make_instance_impl;
     p_ifile_handle->get_base_version = file_handle_get_base_version_impl;
     p_ifile_handle->get_string = file_handle_get_string_impl;
     p_ifile_handle->get_integer = file_handle_get_integer_impl;
     p_ifile_handle->get_buffer = file_handle_get_buffer_impl;
+
+    // OOP-polymorphism for read and write.
+    if (FILE_OP_MODE_TXT_READ == op_mode || FILE_OP_MODE_BIN_READ == op_mode) {
+        p_ifile_handle->make_instance = file_handle_read_make_instance_impl;
+        p_ifile_handle->get_file_stream = file_handle_get_read_file_stream_impl;
+    } else {
+        p_ifile_handle->make_instance = file_handle_write_make_instance_impl;
+        p_ifile_handle->get_file_stream = file_handle_get_write_file_stream_impl;
+    }
 
     return retval;
 }
@@ -141,6 +169,7 @@ static int32_t file_handle_uninit_impl(ifile_handle_t* p_ifile_handle) {
         p_file_data->fp = NULL;
     }
 
+    p_file_data->operation_mode = NULL;
     p_file_data->base_name = NULL;
     p_file_data->ext_name = NULL;
     FREE(p_file_data->contents_buffer.buffer);
@@ -152,8 +181,8 @@ EXIT:
     return retval;
 }
 
-static int32_t file_handle_make_instance_impl(ifile_handle_t* p_ifile_handle, const char* file_path,
-                                              const int32_t op_mode) {
+static int32_t file_handle_read_make_instance_impl(ifile_handle_t* p_ifile_handle,
+                                                   const char* file_path, const int32_t op_mode) {
     file_module_return_t retval = FILE_MODULE_SUCCESS;
 
     if (NULL == p_ifile_handle) {
@@ -180,7 +209,10 @@ static int32_t file_handle_make_instance_impl(ifile_handle_t* p_ifile_handle, co
         p_ifile_handle->uninit(p_ifile_handle);
     }
 
-    p_file_data->fp = fopen(file_path, g_file_operation_mode[op_mode]);
+    p_file_data->operation_mode = (char*)g_file_operation_mode[op_mode];
+    p_file_data->fp = fopen(file_path, p_file_data->operation_mode);
+    log_info("File: %s open with \"%s\" mode.", file_path, p_file_data->operation_mode);
+
     if (NULL == p_file_data->fp) {
         log_error("File: %s can't be open! errno = %d: %s.", file_path, errno, strerror(errno));
         retval = FILE_MODULE_MAKE_INSTANCE_FAIL;
@@ -232,6 +264,12 @@ static int32_t file_handle_make_instance_impl(ifile_handle_t* p_ifile_handle, co
 
 EXIT:
     return retval;
+}
+
+static int32_t file_handle_write_make_instance_impl(ifile_handle_t* p_ifile_handle,
+                                                    const char* file_path, const int32_t op_mode) {
+    log_error("%s is working.", __func__);
+    return FILE_MODULE_MAKE_INSTANCE_FAIL;
 }
 
 static int32_t file_handle_get_base_version_impl(ifile_handle_t* p_ifile_handle,
@@ -364,10 +402,30 @@ EXIT:
     return retval;
 }
 
+static int32_t file_handle_get_read_file_stream_impl(ifile_handle_t* p_ifile_handle, FILE* get_fp) {
+    log_debug("File handle do not support get reading file stream.");
+    return FILE_MODULE_FP_INVALID;
+}
+
+static int32_t file_handle_get_write_file_stream_impl(ifile_handle_t* p_ifile_handle,
+                                                      FILE* get_fp) {
+    file_module_return_t retval = FILE_MODULE_SUCCESS;
+
+    retval = check_file_handle(p_ifile_handle);
+    if (FILE_MODULE_SUCCESS != retval) {
+        goto EXIT;
+    }
+
+    get_fp = get_file_pointer(p_ifile_handle);
+
+EXIT:
+    return retval;
+}
+
 ifile_handle_t* create_file_handle(char* file_path, file_operation_mode_t mode) {
     // TODO: Reference counting in file module.
     ifile_handle_t* p_file_handle = (ifile_handle_t*)calloc(1, sizeof(ifile_handle_t));
-    file_handle_set_impl(p_file_handle);
+    file_handle_set_impl(p_file_handle, mode);
     p_file_handle->init(p_file_handle);
     p_file_handle->make_instance(p_file_handle, file_path, mode);
 

--- a/file_module/src/file_utils.c
+++ b/file_module/src/file_utils.c
@@ -24,7 +24,7 @@ EXIT:
     return data_length;
 }
 
-char* get_file_base_name(char* file_path) {
+char* get_file_base_name(const char* file_path) {
     if (NULL == file_path) {
         return NULL;
     }
@@ -32,7 +32,7 @@ char* get_file_base_name(char* file_path) {
     return (base_name != NULL) ? (base_name + 1) : (file_path);
 }
 
-char* get_file_extension_name(char* file_path) {
+char* get_file_extension_name(const char* file_path) {
     if (NULL == file_path) {
         return NULL;
     }

--- a/main/src/main.c
+++ b/main/src/main.c
@@ -27,14 +27,7 @@ int main(int argc, char* argv[]) {
     }
 
     // Create interface of file handle object.
-    p_ifile_handle = create_file_handle();
-    // Input a file path and do make instance.
-    retval = p_ifile_handle->make_instance(p_ifile_handle, file_path);
-    log_debug("File handle make instance retval = %d", retval);
-    if (FILE_MODULE_SUCCESS != retval) {
-        log_error("File handle make instance fail!");
-        goto EXIT;
-    }
+    p_ifile_handle = create_file_handle(file_path, FILE_OP_MODE_TXT_READ);
 
     // log print file base name and extension name.
     char base_name[PATH_LEN] = {'\0'};

--- a/main/src/main.c
+++ b/main/src/main.c
@@ -27,7 +27,7 @@ int main(int argc, char* argv[]) {
     }
 
     // Create interface of file handle object.
-    p_ifile_handle = New_FILE_HANDLE();
+    p_ifile_handle = create_file_handle();
     // Input a file path and do make instance.
     retval = p_ifile_handle->make_instance(p_ifile_handle, file_path);
     log_debug("File handle make instance retval = %d", retval);
@@ -85,7 +85,7 @@ int main(int argc, char* argv[]) {
 
     // TODO: json to map.
 EXIT:
-    Delete_FILE_HANDLE(p_ifile_handle);
+    destroy_file_handle(p_ifile_handle);
     if (NULL != json_file_in_string) {
         free(json_file_in_string);
     }


### PR DESCRIPTION
**Now, file handle have both read and write interfaces.**<br>

1. Rename new/delete by create/destroy.
2. Set file path and operation mode as get instance arguments.
3. A new method: get_file_stream() for writing. Latter other modules may need lock writing file stream.
4. TODO: Make instance of open writing files.