### PR TITLE
[Memory]Fix Memory Leak and Potential Dangling Pointers

### DIFF
--- a/cmd_invoke/src/mem_utils.c
+++ b/cmd_invoke/src/mem_utils.c
@@ -18,6 +18,7 @@ char** new_char_list(size_t list_length, size_t key_length) {
         if (NULL == list[list_index]) {
             log_error("%s, fail", __func__);
             delete_char_list(list, list_length);
+            list = NULL;
             break;
         }
     }

--- a/file_module/src/file_module.c
+++ b/file_module/src/file_module.c
@@ -174,6 +174,7 @@ static int32_t file_handle_uninit_impl(ifile_handle_t* p_ifile_handle) {
     p_file_data->ext_name = NULL;
     FREE(p_file_data->contents_buffer.buffer);
     FREE(p_file_data->contents_string.buffer);
+    FREE(p_ifile_handle->context);
 
     memset(p_file_data, 0, sizeof(file_data_t));
 

--- a/json2map/src/json_2_map.c
+++ b/json2map/src/json_2_map.c
@@ -99,6 +99,7 @@ static int32_t json_2_map_uninit_impl(ijson_2_map_t* p_ijson_2_map) {
     void* context = p_ijson_2_map->context;
     if (NULL != context) {
         destroy_map_data(context);
+        p_ijson_2_map->context = NULL;
     }
 
 EXIT:


### PR DESCRIPTION
**Fix memory management bugs by CRT library.**

1. Fix potential dangling pointer problems.(by programmer)
2. Fix memory leak in file module.(by CRT library)

In CMake debugger output
```c
22:23:43 DEBUG D:\github\leetcode_c\file_module\src\file_module.c:141: file_handle_init_impl, Jonathan debug: sizeof file_data_t:72 bytes
```

```c
22:13:22 INFO  D:\github\leetcode_c\cmd_invoke\src\cmd_invoke.c:33: command_handler, process problem cmd_id: 1
22:13:22 INFO  D:\github\leetcode_c\map\src\map_data.c:308: map_data_get_keys, get key[0]: nums
22:13:22 INFO  D:\github\leetcode_c\map\src\map_data.c:312: map_data_get_keys, get key[1]: target
22:13:22 INFO  D:\github\leetcode_c\map\src\map_data.c:312: map_data_get_keys, get key[2]: problem_id
22:13:22 DEBUG D:\github\leetcode_c\json2map\src\json_2_map.c:209: json_2_map_get_int_impl, key = target, get_integer = 9
22:13:22 INFO  D:\github\leetcode_c\problems_api\src\do_problems_api.c:62: Begin Input Information:
22:13:22 INFO  D:\github\leetcode_c\problems_api\src\do_problems_api.c:64: do_TwoSum, Input: nums[0] = 2
22:13:22 INFO  D:\github\leetcode_c\problems_api\src\do_problems_api.c:64: do_TwoSum, Input: nums[1] = 7
22:13:22 INFO  D:\github\leetcode_c\problems_api\src\do_problems_api.c:64: do_TwoSum, Input: nums[2] = 11
22:13:22 INFO  D:\github\leetcode_c\problems_api\src\do_problems_api.c:64: do_TwoSum, Input: nums[3] = 15
22:13:22 INFO  D:\github\leetcode_c\problems_api\src\do_problems_api.c:66: do_TwoSum, target = 9
22:13:22 INFO  D:\github\leetcode_c\problems_api\src\do_problems_api.c:67: End Input Information:

22:13:22 INFO  D:\github\leetcode_c\problems_api\src\do_problems_api.c:69: Begin Output Information:
22:13:22 INFO  D:\github\leetcode_c\problems_api\src\do_problems_api.c:72: do_TwoSum, Output: index_array[0] = 0
22:13:22 INFO  D:\github\leetcode_c\problems_api\src\do_problems_api.c:72: do_TwoSum, Output: index_array[1] = 1
22:13:22 INFO  D:\github\leetcode_c\problems_api\src\do_problems_api.c:74: End Output Information:

22:13:22 INFO  D:\github\leetcode_c\cmd_invoke\src\cmd_invoke.c:74: command_handler, process problem cmd_id: 1 and retval = 0
22:13:22 DEBUG D:\github\leetcode_c\main\src\main.c:52: main, --Begin Memory Leak Detection--
Detected memory leaks!
Dumping objects ->
{191} normal block at 0x00000269F48D09C0, 72 bytes long.
 Data: <                > 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
Object dump complete.
22:13:22 DEBUG D:\github\leetcode_c\main\src\main.c:56: main, --End Memory Leak Detection--
Loaded 'C:\Windows\System32\kernel.appcore.dll'. 
Detected memory leaks!
Dumping objects ->
{191} normal block at 0x00000269F48D09C0, 72 bytes long.
 Data: <                > 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
Object dump complete.
The program '[3196] main_leetcode.exe' has exited with code 0 (0x0).
```